### PR TITLE
feat: added new error classe ClientElevatedPermsError

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export {
   type AuthenticationOptions,
   type Credentials,
   ClientNotFoundError,
+  ClientElevatedPermsError,
   InvalidPlatformError
 } from './authentication.js'
 export { LeagueClient, type LeagueClientOptions } from './client.js'


### PR DESCRIPTION
Changes Summary: Added export functionality to the ClientElevatedPermsError error class.

The absence of export capability for ClientElevatedPermsError was troublesome. Currently, in my project, I directly inspect the error string, so any modifications in the library's error string could lead to unintended errors.

Consequently, having to resort to additional scripts to verify the administrative status of the process in specific scenarios is highly inconvenient.

I'm eager for a swift resolution of this issue to streamline and enhance error handling efficiency.

(Is it intentional that the error is not exported?)